### PR TITLE
Add api functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.swp
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "fun"
 version = "0.0.3"
 dependencies = [
+ "getopts 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -21,6 +22,14 @@ dependencies = [
 name = "gcc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 
+getopts = "*"
 hyper = "*"
 rustc-serialize = "*"

--- a/src/bin/fun.rs
+++ b/src/bin/fun.rs
@@ -1,8 +1,76 @@
+extern crate getopts;
 extern crate icndb;
 
+use getopts::{ Matches, Options };
+
+enum Command {
+    Next(CommandOptions),
+    ById(u64, CommandOptions),
+    Invalid(String)
+}
+
+struct CommandOptions {
+    first: Option<String>,
+    last: Option<String>,
+    // These may come in handy later:
+    //include: Box<[String]>,
+    //exclude: Box<[String]>
+}
+
+
 pub fn main() {
-    match icndb::next() {
-        Some(response) => println!("#{}: {}", response.id, response.joke),
+    let options = read_options();
+
+    let response = match options {
+        Command::Next(options) => icndb::next_with_names(
+            &options.first.unwrap_or("Chuck".to_string()), 
+            &options.last.unwrap_or("Norris".to_string())),
+        Command::ById(id, options) => icndb::get_by_id_with_names(
+            id, 
+            &options.first.unwrap_or("Chuck".to_string()), 
+            &options.last.unwrap_or("Norris".to_string())),
+        Command::Invalid(desc) => {
+            println!("{}", desc);
+            return;
+        }
+    };
+
+    match response {
+        Some(result) => println!("#{}: {}", result.id, result.joke),
         None => println!("Error: not funny.")
+    }
+}
+
+fn read_options() -> Command {
+    let mut opts = Options::new();
+
+    opts.optopt("f", "first", "first name", "'Bob'");
+    opts.optopt("l", "last", "last name", "'Johnson'");
+    opts.optopt("i", "id", "specific joke", "'373'");
+
+    match opts.parse(std::env::args()) {
+        Ok(matches) => create_command(matches),
+        _ => Command::Invalid("Failed to read arguments.".to_string()) 
+    }
+}
+
+/// Uses matches supplied by 
+fn create_command(matches: Matches) -> Command {
+    match matches.opt_str("id") {
+        
+        // received ID option
+        Some(value) => match value.parse() {
+            Ok(id) => Command::ById(id, CommandOptions {
+                first: matches.opt_str("first"),
+                last: matches.opt_str("last")
+            }),
+            _ => Command::Invalid("Could not parse ID.".to_string())
+        },
+
+        // did not recieve ID option
+        None => Command::Next(CommandOptions {
+            first: matches.opt_str("first"),
+            last: matches.opt_str("last"),
+        })
     }
 }


### PR DESCRIPTION
Adds ability to specify IDs and names. Still no support for categories, but most jokes don't seem to have categories, so that's a lower priority.

Also, check joke ID 448.
